### PR TITLE
Fix parsing file - FileType already read

### DIFF
--- a/sqflint.py
+++ b/sqflint.py
@@ -20,14 +20,13 @@ def analyze(code, writer=sys.stdout):
 
 def _main():
     parser = argparse.ArgumentParser(description="Static Analyser of SQF code")
-    parser.add_argument('filename', nargs='?', type=argparse.FileType('r'), default=None,
+    parser.add_argument('file', nargs='?', type=argparse.FileType('r'), default=None,
                         help='The full path of the file to be analyzed')
 
     args = parser.parse_args()
 
-    if args.filename is not None:
-        with open(args.filename) as file:
-            code = file.read()
+    if args.file is not None:
+        code = args.file.read()
     else:
         code = sys.stdin.read()
 


### PR DESCRIPTION
Fixes:
```
Traceback (most recent call last):
  File "/usr/local/bin/sqflint", line 11, in <module>
    sys.exit(_main())
  File "/usr/local/bin/sqflint.py", line 29, in _main
    with open(args.filename) as file:
TypeError: invalid file: <_io.TextIOWrapper name='/mnt/e/Arma 3/Mods/ACE3/falsepositive.sqf' mode='r' encoding='UTF-8'>
```
It was trying to open a file that was already open (read in arguments into `FileType` in read mode).